### PR TITLE
remove gulp-utils due to deprecation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ typings
 *.js
 npm-debug.log
 .DS_Store
+.idea

--- a/index.ts
+++ b/index.ts
@@ -11,18 +11,16 @@
  *
  */
 
-'use strict';
-
+import File = require('vinyl');
+import log = require('fancy-log');
 import path = require('path');
+import PluginError = require('plugin-error');
+import svg2png = require('svg2png');
+
+import { SVG } from './lib/index';
 
 const map_limit = require('map-stream-limit');
 const map = require('map-stream');
-const svg2png = require('svg2png');
-const PluginError = require('plugin-error');
-const log = require('fancy-log');
-const File = require('vinyl');
-
-import { SVG } from './lib/index';
 
 const PLUGIN_NAME = require('./package.json').name;
 

--- a/index.ts
+++ b/index.ts
@@ -15,11 +15,12 @@
 
 import path = require('path');
 
-import gutil = require('gulp-util');
-
 const map_limit = require('map-stream-limit');
 const map = require('map-stream');
 const svg2png = require('svg2png');
+const PluginError = require('plugin-error');
+const log = require('fancy-log');
+const File = require('vinyl');
 
 import { SVG } from './lib/index';
 
@@ -37,7 +38,7 @@ class Command {
 	*/
 	private log(message: string) {
 		if (this.verbose) {
-			gutil.log(message);
+			log(message);
 		}
 	}
 
@@ -48,7 +49,7 @@ class Command {
 	*
 	*/
 	private error(message: string) {
-		throw new gutil.PluginError(PLUGIN_NAME, message);
+		throw new PluginError(PLUGIN_NAME, message);
 	}
 
 	/**
@@ -76,7 +77,7 @@ class Command {
 
 		svg2png(buffer, this.options)
 			.then((contents: Buffer) => {
-				cb(null, new gutil.File({
+				cb(null, new File({
 					base: source.base,
 					path: this.rename(source.path),
 					contents

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,12 @@
 			"integrity": "sha1-ox10JBprHtu5c8822XooloNKUfk=",
 			"dev": true
 		},
+		"@types/fancy-log": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@types/fancy-log/-/fancy-log-1.3.0.tgz",
+			"integrity": "sha512-mQjDxyOM1Cpocd+vm1kZBP7smwKZ4TNokFeds9LV7OZibmPJFEzY3+xZMrKfUdNT71lv8GoCPD6upKwHxubClw==",
+			"dev": true
+		},
 		"@types/gulp-util": {
 			"version": "3.0.34",
 			"resolved": "https://registry.npmjs.org/@types/gulp-util/-/gulp-util-3.0.34.tgz",
@@ -68,8 +74,20 @@
 		"@types/node": {
 			"version": "7.0.63",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.63.tgz",
-			"integrity": "sha512-YPVhjU3cADo7M7M1KWeEki9MUMZd3yz5FLq0BXkPrY2jpr0B9VRd4iQ2vBSiLrjvLkIPPluzxQFYJ5JkGubtIw==",
-			"dev": true
+			"integrity": "sha512-YPVhjU3cADo7M7M1KWeEki9MUMZd3yz5FLq0BXkPrY2jpr0B9VRd4iQ2vBSiLrjvLkIPPluzxQFYJ5JkGubtIw=="
+		},
+		"@types/plugin-error": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@types/plugin-error/-/plugin-error-0.1.0.tgz",
+			"integrity": "sha512-iFWVbyq1mvC3YuFhJMyToA1GXEbvRWoOFIWZXZZ6fd8Qm5b0Qs62i6evnoHcPXXcQgXq8r2RaXQrdXZC/IsTiQ=="
+		},
+		"@types/svg2png": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@types/svg2png/-/svg2png-4.1.0.tgz",
+			"integrity": "sha512-02AE1ye4msvqVHCm2kMTuUr8VGytZ0w1S6aPf0nAwTzX+EgmJ3ERYLrij6HSh9FVEqV6putkRjUFjRNiht2Oig==",
+			"requires": {
+				"@types/node": "7.0.63"
+			}
 		},
 		"@types/through2": {
 			"version": "2.0.33",
@@ -113,25 +131,10 @@
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
 			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 		},
-		"ansi-styles": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-		},
 		"ansi-wrap": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
 			"integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
-		},
-		"array-differ": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-			"integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
-		},
-		"array-uniq": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
 		},
 		"asn1": {
 			"version": "0.2.3",
@@ -173,11 +176,6 @@
 				"tweetnacl": "0.14.5"
 			}
 		},
-		"beeper": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
-			"integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak="
-		},
 		"boom": {
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
@@ -207,18 +205,6 @@
 				"type-detect": "1.0.0"
 			}
 		},
-		"chalk": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-			"requires": {
-				"ansi-styles": "2.2.1",
-				"escape-string-regexp": "1.0.5",
-				"has-ansi": "2.0.0",
-				"strip-ansi": "3.0.1",
-				"supports-color": "2.0.0"
-			}
-		},
 		"cliui": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
@@ -228,16 +214,6 @@
 				"strip-ansi": "3.0.1",
 				"wrap-ansi": "2.1.0"
 			}
-		},
-		"clone": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-			"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
-		},
-		"clone-stats": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-			"integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
 		},
 		"co": {
 			"version": "4.6.0",
@@ -353,11 +329,6 @@
 				"assert-plus": "1.0.0"
 			}
 		},
-		"dateformat": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
-			"integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
-		},
 		"debug": {
 			"version": "2.6.9",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -399,14 +370,6 @@
 			"integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
 			"dev": true
 		},
-		"duplexer2": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-			"integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
-			"requires": {
-				"readable-stream": "1.1.14"
-			}
-		},
 		"ecc-jsbn": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
@@ -432,7 +395,8 @@
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
 		},
 		"extend": {
 			"version": "3.0.1",
@@ -540,14 +504,6 @@
 				"minimatch": "0.3.0"
 			}
 		},
-		"glogg": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
-			"integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
-			"requires": {
-				"sparkles": "1.0.0"
-			}
-		},
 		"graceful-fs": {
 			"version": "4.1.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
@@ -558,39 +514,6 @@
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
 			"integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
 			"dev": true
-		},
-		"gulp-util": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
-			"integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
-			"requires": {
-				"array-differ": "1.0.0",
-				"array-uniq": "1.0.3",
-				"beeper": "1.1.1",
-				"chalk": "1.1.3",
-				"dateformat": "2.2.0",
-				"fancy-log": "1.3.2",
-				"gulplog": "1.0.0",
-				"has-gulplog": "0.1.0",
-				"lodash._reescape": "3.0.0",
-				"lodash._reevaluate": "3.0.0",
-				"lodash._reinterpolate": "3.0.0",
-				"lodash.template": "3.6.2",
-				"minimist": "1.2.0",
-				"multipipe": "0.1.2",
-				"object-assign": "3.0.0",
-				"replace-ext": "0.0.1",
-				"through2": "2.0.3",
-				"vinyl": "0.5.3"
-			}
-		},
-		"gulplog": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
-			"integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
-			"requires": {
-				"glogg": "1.0.1"
-			}
 		},
 		"har-schema": {
 			"version": "2.0.0",
@@ -606,27 +529,11 @@
 				"har-schema": "2.0.0"
 			}
 		},
-		"has-ansi": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-			"requires": {
-				"ansi-regex": "2.1.1"
-			}
-		},
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 			"dev": true
-		},
-		"has-gulplog": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
-			"integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
-			"requires": {
-				"sparkles": "1.0.0"
-			}
 		},
 		"hasha": {
 			"version": "2.2.0",
@@ -719,11 +626,6 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
 			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
-		},
-		"isarray": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-			"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -832,109 +734,6 @@
 				"strip-bom": "2.0.0"
 			}
 		},
-		"lodash._basecopy": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-			"integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
-		},
-		"lodash._basetostring": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-			"integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U="
-		},
-		"lodash._basevalues": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
-			"integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc="
-		},
-		"lodash._getnative": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-			"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
-		},
-		"lodash._isiterateecall": {
-			"version": "3.0.9",
-			"resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-			"integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
-		},
-		"lodash._reescape": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
-			"integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo="
-		},
-		"lodash._reevaluate": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
-			"integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0="
-		},
-		"lodash._reinterpolate": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
-		},
-		"lodash._root": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-			"integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
-		},
-		"lodash.escape": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
-			"integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
-			"requires": {
-				"lodash._root": "3.0.1"
-			}
-		},
-		"lodash.isarguments": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-			"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
-		},
-		"lodash.isarray": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
-		},
-		"lodash.keys": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-			"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-			"requires": {
-				"lodash._getnative": "3.9.1",
-				"lodash.isarguments": "3.1.0",
-				"lodash.isarray": "3.0.4"
-			}
-		},
-		"lodash.restparam": {
-			"version": "3.6.1",
-			"resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-			"integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
-		},
-		"lodash.template": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
-			"integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
-			"requires": {
-				"lodash._basecopy": "3.0.1",
-				"lodash._basetostring": "3.0.1",
-				"lodash._basevalues": "3.0.0",
-				"lodash._isiterateecall": "3.0.9",
-				"lodash._reinterpolate": "3.0.0",
-				"lodash.escape": "3.2.0",
-				"lodash.keys": "3.1.2",
-				"lodash.restparam": "3.6.1",
-				"lodash.templatesettings": "3.1.1"
-			}
-		},
-		"lodash.templatesettings": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
-			"integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
-			"requires": {
-				"lodash._reinterpolate": "3.0.0",
-				"lodash.escape": "3.2.0"
-			}
-		},
 		"lru-cache": {
 			"version": "2.7.3",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
@@ -984,11 +783,6 @@
 				"lru-cache": "2.7.3",
 				"sigmund": "1.0.1"
 			}
-		},
-		"minimist": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 		},
 		"mkdirp": {
 			"version": "0.5.0",
@@ -1072,14 +866,6 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 		},
-		"multipipe": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-			"integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
-			"requires": {
-				"duplexer2": "0.0.2"
-			}
-		},
 		"normalize-package-data": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -1100,11 +886,6 @@
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
 			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
-		},
-		"object-assign": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-			"integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
 		},
 		"os-locale": {
 			"version": "1.4.0",
@@ -1228,22 +1009,6 @@
 				"read-pkg": "1.1.0"
 			}
 		},
-		"readable-stream": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-			"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-			"requires": {
-				"core-util-is": "1.0.2",
-				"inherits": "2.0.3",
-				"isarray": "0.0.1",
-				"string_decoder": "0.10.31"
-			}
-		},
-		"replace-ext": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-			"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
-		},
 		"request": {
 			"version": "2.85.0",
 			"resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
@@ -1320,11 +1085,6 @@
 				"hoek": "4.2.1"
 			}
 		},
-		"sparkles": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
-			"integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM="
-		},
 		"spdx-correct": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
@@ -1378,11 +1138,6 @@
 				"strip-ansi": "3.0.1"
 			}
 		},
-		"string_decoder": {
-			"version": "0.10.31",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-			"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-		},
 		"stringstream": {
 			"version": "0.0.5",
 			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
@@ -1403,11 +1158,6 @@
 			"requires": {
 				"is-utf8": "0.2.1"
 			}
-		},
-		"supports-color": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 		},
 		"svg2png": {
 			"version": "4.1.1",
@@ -1469,44 +1219,6 @@
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
 			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
-		},
-		"through2": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-			"requires": {
-				"readable-stream": "2.3.6",
-				"xtend": "4.0.1"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-				},
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "1.0.0",
-						"process-nextick-args": "2.0.0",
-						"safe-buffer": "5.1.2",
-						"string_decoder": "1.1.1",
-						"util-deprecate": "1.0.2"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"requires": {
-						"safe-buffer": "5.1.2"
-					}
-				}
-			}
 		},
 		"time-stamp": {
 			"version": "1.1.0",
@@ -1587,16 +1299,6 @@
 				"extsprintf": "1.3.0"
 			}
 		},
-		"vinyl": {
-			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
-			"integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
-			"requires": {
-				"clone": "1.0.4",
-				"clone-stats": "0.0.1",
-				"replace-ext": "0.0.1"
-			}
-		},
 		"which": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
@@ -1618,11 +1320,6 @@
 				"string-width": "1.0.2",
 				"strip-ansi": "3.0.1"
 			}
-		},
-		"xtend": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
 		},
 		"y18n": {
 			"version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -32,10 +32,12 @@
 	},
 	"homepage": "https://github.com/ryanwholey/gulp-svg2png",
 	"dependencies": {
-		"gulp-util": "^3.0.7",
+		"fancy-log": "^1.3.2",
 		"map-stream": "0.0.6",
 		"map-stream-limit": "^1.1.0",
-		"svg2png": "^4.1.1"
+		"plugin-error": "^1.0.1",
+		"svg2png": "^4.1.1",
+		"vinyl": "^2.2.0"
 	},
 	"devDependencies": {
 		"@types/chai": "^3.4.34",

--- a/package.json
+++ b/package.json
@@ -32,25 +32,28 @@
 	},
 	"homepage": "https://github.com/ryanwholey/gulp-svg2png",
 	"dependencies": {
-		"fancy-log": "^1.3.2",
 		"map-stream": "0.0.6",
-		"map-stream-limit": "^1.1.0",
-		"plugin-error": "^1.0.1",
-		"svg2png": "^4.1.1",
-		"vinyl": "^2.2.0"
+		"map-stream-limit": "^1.1.0"
 	},
 	"devDependencies": {
 		"@types/chai": "^3.4.34",
 		"@types/chalk": "^0.4.31",
+		"@types/fancy-log": "^1.3.0",
 		"@types/gulp-util": "^3.0.30",
 		"@types/mocha": "^2.2.38",
 		"@types/node": "^7.0.4",
+		"@types/plugin-error": "^0.1.0",
+		"@types/svg2png": "^4.1.0",
 		"@types/through2": "^2.0.32",
 		"@types/vinyl": "^2.0.0",
 		"chai": "^3.0.0",
+		"fancy-log": "^1.3.2",
 		"gulp": "^3.9.1",
 		"imagesize": "^1.0.0",
 		"mocha": "^2.2.5",
-		"typescript": "^2.1.5"
+		"plugin-error": "^1.0.1",
+		"typescript": "^2.1.5",
+		"svg2png": "^4.1.1",
+		"vinyl": "^2.2.0"
 	}
 }

--- a/specs/helper.ts
+++ b/specs/helper.ts
@@ -16,7 +16,8 @@
 import fs = require('fs');
 import os = require('os');
 import path = require('path');
-import gutil = require('gulp-util');
+
+const File = require('vinyl');
 
 var imagesize = require('imagesize');
 
@@ -71,7 +72,7 @@ export default class Helper {
      *
      */
 	static createTestFile(): any {
-		return new gutil.File({
+		return new File({
 			cwd: './specs/assets/',
 			base: './specs/assets/',
 			path: './specs/assets/twitter.svg',

--- a/yarn.lock
+++ b/yarn.lock
@@ -52,6 +52,13 @@ ajv@^5.1.0:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
 
+ansi-colors@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-1.1.0.tgz#6374b4dd5d4718ff3ce27a671a3b1cad077132a9"
+  integrity sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==
+  dependencies:
+    ansi-wrap "^0.1.0"
+
 ansi-gray@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/ansi-gray/-/ansi-gray-0.1.1.tgz#2962cf54ec9792c48510a3deb524436861ef7251"
@@ -72,7 +79,7 @@ ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-ansi-wrap@0.1.0:
+ansi-wrap@0.1.0, ansi-wrap@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/ansi-wrap/-/ansi-wrap-0.1.0.tgz#a82250ddb0015e9a27ca82e82ea603bbfa45efaf"
 
@@ -273,9 +280,19 @@ cliui@^3.2.0:
     strip-ansi "^3.0.1"
     wrap-ansi "^2.0.0"
 
+clone-buffer@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/clone-buffer/-/clone-buffer-1.0.0.tgz#e3e25b207ac4e701af721e2cb5a16792cac3dc58"
+  integrity sha1-4+JbIHrE5wGvch4staFnksrD3Fg=
+
 clone-stats@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/clone-stats/-/clone-stats-0.0.1.tgz#b88f94a82cf38b8791d58046ea4029ad88ca99d1"
+
+clone-stats@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/clone-stats/-/clone-stats-1.0.0.tgz#b3782dff8bb5474e18b9b6bf0fdfe782f8777680"
+  integrity sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=
 
 clone@^0.2.0:
   version "0.2.0"
@@ -284,6 +301,20 @@ clone@^0.2.0:
 clone@^1.0.0, clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
+
+clone@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
+  integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
+
+cloneable-readable@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/cloneable-readable/-/cloneable-readable-1.1.2.tgz#d591dee4a8f8bc15da43ce97dceeba13d43e2a65"
+  integrity sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==
+  dependencies:
+    inherits "^2.0.1"
+    process-nextick-args "^2.0.0"
+    readable-stream "^2.3.5"
 
 co@^4.6.0:
   version "4.6.0"
@@ -536,7 +567,7 @@ extsprintf@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
 
-fancy-log@^1.1.0:
+fancy-log@^1.1.0, fancy-log@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/fancy-log/-/fancy-log-1.3.2.tgz#f41125e3d84f2e7d89a43d06d958c8f78be16be1"
   dependencies:
@@ -762,7 +793,7 @@ growl@1.9.2:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.9.2.tgz#0ea7743715db8d8de2c5ede1775e1b45ac85c02f"
 
-gulp-util@^3.0.0, gulp-util@^3.0.7:
+gulp-util@^3.0.0:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/gulp-util/-/gulp-util-3.0.8.tgz#0054e1e744502e27c04c187c3ecc505dd54bbb4f"
   dependencies:
@@ -916,7 +947,7 @@ inherits@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-1.0.2.tgz#ca4309dadee6b54cc0b8d247e8d7c7a0975bdc9b"
 
-inherits@2, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -1620,6 +1651,16 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
 
+plugin-error@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/plugin-error/-/plugin-error-1.0.1.tgz#77016bd8919d0ac377fdcdd0322328953ca5781c"
+  integrity sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==
+  dependencies:
+    ansi-colors "^1.0.1"
+    arr-diff "^4.0.0"
+    arr-union "^3.1.0"
+    extend-shallow "^3.0.2"
+
 pn@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
@@ -1632,7 +1673,7 @@ pretty-hrtime@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
 
-process-nextick-args@~2.0.0:
+process-nextick-args@^2.0.0, process-nextick-args@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
 
@@ -1672,7 +1713,7 @@ read-pkg@^1.0.0:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@^2.1.5, readable-stream@^2.2.2:
+readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.5:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   dependencies:
@@ -1706,6 +1747,11 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
+remove-trailing-separator@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
+  integrity sha1-wkvOKig62tW8P1jg1IJJuSN52O8=
+
 repeat-element@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.2.tgz#ef089a178d1483baae4d93eb98b4f9e4e11d990a"
@@ -1717,6 +1763,11 @@ repeat-string@^1.6.1:
 replace-ext@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-0.0.1.tgz#29bbd92078a739f0bcce2b4ee41e837953522924"
+
+replace-ext@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
+  integrity sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=
 
 request-progress@^2.0.1:
   version "2.0.1"
@@ -2184,6 +2235,18 @@ vinyl@^0.5.0:
     clone "^1.0.0"
     clone-stats "^0.0.1"
     replace-ext "0.0.1"
+
+vinyl@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/vinyl/-/vinyl-2.2.0.tgz#d85b07da96e458d25b2ffe19fece9f2caa13ed86"
+  integrity sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==
+  dependencies:
+    clone "^2.1.1"
+    clone-buffer "^1.0.0"
+    clone-stats "^1.0.0"
+    cloneable-readable "^1.0.0"
+    remove-trailing-separator "^1.0.1"
+    replace-ext "^1.0.0"
 
 which-module@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,11 @@
   version "0.4.31"
   resolved "https://registry.yarnpkg.com/@types/chalk/-/chalk-0.4.31.tgz#a31d74241a6b1edbb973cf36d97a2896834a51f9"
 
+"@types/fancy-log@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@types/fancy-log/-/fancy-log-1.3.0.tgz#a61ab476e5e628cd07a846330df53b85e05c8ce0"
+  integrity sha512-mQjDxyOM1Cpocd+vm1kZBP7smwKZ4TNokFeds9LV7OZibmPJFEzY3+xZMrKfUdNT71lv8GoCPD6upKwHxubClw==
+
 "@types/gulp-util@^3.0.30":
   version "3.0.34"
   resolved "https://registry.yarnpkg.com/@types/gulp-util/-/gulp-util-3.0.34.tgz#d1291ebf706d93f46eb8df11344bbfd96247697e"
@@ -30,6 +35,18 @@
 "@types/node@^7.0.4":
   version "7.0.63"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.63.tgz#e60fb43e864b888798acfab3c02e312f4b5362bd"
+
+"@types/plugin-error@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@types/plugin-error/-/plugin-error-0.1.0.tgz#47e8efd62ccdf6c495f7154c3033e1360353c882"
+  integrity sha512-iFWVbyq1mvC3YuFhJMyToA1GXEbvRWoOFIWZXZZ6fd8Qm5b0Qs62i6evnoHcPXXcQgXq8r2RaXQrdXZC/IsTiQ==
+
+"@types/svg2png@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@types/svg2png/-/svg2png-4.1.0.tgz#c80524f0e848246f523075f3d6409697285726dc"
+  integrity sha512-02AE1ye4msvqVHCm2kMTuUr8VGytZ0w1S6aPf0nAwTzX+EgmJ3ERYLrij6HSh9FVEqV6putkRjUFjRNiht2Oig==
+  dependencies:
+    "@types/node" "*"
 
 "@types/through2@*", "@types/through2@^2.0.32":
   version "2.0.33"


### PR DESCRIPTION
gulp-utils has been [deprecated](https://www.npmjs.com/package/gulp-util). Removing references to g-utils as well as the gulp-util package.